### PR TITLE
Fix using --profile flag to subcommands

### DIFF
--- a/maas/client/flesh/__init__.py
+++ b/maas/client/flesh/__init__.py
@@ -318,7 +318,7 @@ class OriginCommandBase(Command):
 
 class OriginCommand(OriginCommandBase):
     def __call__(self, options):
-        session = bones.SessionAPI.fromProfileName(options.profile)
+        session = bones.SessionAPI.fromProfileName(options.profile_name)
         origin = viscera.Origin(session)
         return self.execute(origin, options)
 
@@ -328,7 +328,7 @@ class OriginCommand(OriginCommandBase):
 
 class OriginTableCommand(OriginCommandBase, TableCommand):
     def __call__(self, options):
-        session = bones.SessionAPI.fromProfileName(options.profile)
+        session = bones.SessionAPI.fromProfileName(options.profile_name)
         origin = viscera.Origin(session)
         return self.execute(origin, options, target=options.format)
 


### PR DESCRIPTION
This flag was broken, since it referenced an unset attribute profile on
the parsed options object.