### PR TITLE
Spinner: fix invalid escape sequence

### DIFF
--- a/maas/client/utils/__init__.py
+++ b/maas/client/utils/__init__.py
@@ -338,7 +338,7 @@ class Spinner:
     Use as a context manager.
     """
 
-    def __init__(self, frames="/-\|", stream=sys.stdout):
+    def __init__(self, frames=r"/-\|", stream=sys.stdout):
         super(Spinner, self).__init__()
         self.frames = frames
         self.stream = stream


### PR DESCRIPTION
Before this running this code would result in:
```
maas/client/utils/__init__.py:341: SyntaxWarning: invalid escape sequence '\|'
```