### PR TITLE
ci: use `pull_request_target` for cla-check

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,8 +1,6 @@
 name: cla-check
 
-on:
-  pull_request:
-    branches: [master]
+on: [pull_request_target]
 
 jobs:
   cla-check:


### PR DESCRIPTION
When run on the `pull_request_target` event, `has-signed-canonical-cla` action will also comment on the PR if any authors have not signed the CLA, and update those messages when new commits or runs are processed.